### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ function addTodo(event){
     todoDiv.classList.add('todo');
     // Membuat li
     const newTodo = document.createElement('li');
-    newTodo.innerHTML = todoInput.value;
+    newTodo.textContent = todoInput.value;
     newTodo.classList.add('todo-item');
     todoDiv.appendChild(newTodo);
     


### PR DESCRIPTION
Potential fix for [https://github.com/alinetitania/CodeDemo/security/code-scanning/1](https://github.com/alinetitania/CodeDemo/security/code-scanning/1)

To fix the issue, we need to ensure that user input is treated as plain text rather than HTML. Instead of assigning `todoInput.value` to `newTodo.innerHTML`, we should use `textContent`, which safely sets the text content of an element without interpreting it as HTML. This change ensures that any special characters in the input are escaped, preventing XSS attacks.

The fix involves replacing the use of `innerHTML` with `textContent` on line 22. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
